### PR TITLE
Parse obo

### DIFF
--- a/pyobo/document_builder.py
+++ b/pyobo/document_builder.py
@@ -25,6 +25,8 @@ class OboDocumentBuilder:
 
     def tag_value_pair(self, tag, value):
         attribute = tag.replace("-", "_")
+        if attribute == "version":
+            attribute = "data_version"
         current_value = self.scope.__dict__.get(attribute)
         if current_value is None:
             self.scope.__dict__[attribute] = value

--- a/pyobo/document_builder.py
+++ b/pyobo/document_builder.py
@@ -24,15 +24,31 @@ class OboDocumentBuilder:
         print("tag_definition")
 
     def tag_value_pair(self, tag, value):
-        attribute = tag.replace("-", "_")
-        if attribute == "version":
-            attribute = "data_version"
+        attribute = OboDocumentBuilder._extract_attribute(tag)
+        self._ensure_attribute_is_defined(attribute)
+        self._set_attribute_value(tag, attribute, value)
+
+    def _set_attribute_value(self, tag, attribute, value):
         current_value = self.scope.__dict__.get(attribute)
         if current_value is None:
             self.scope.__dict__[attribute] = value
             return
+        if type(current_value) == list:
+            current_value.append(value)
+            return
         if current_value != value:
             raise OboDocumentBuildingError.invalidTagPairMerge(tag, current_value, value)
+
+    def _ensure_attribute_is_defined(self, attribute):
+        if attribute not in self.scope.__dict__:
+            self.scope.__dict__[attribute] = []
+
+    @staticmethod
+    def _extract_attribute(tag):
+        attribute = tag.replace("-", "_")
+        if attribute == "version":
+            attribute = "data_version"
+        return attribute
 
 
 class OboDocumentBuildingError(Exception):

--- a/pyobo/document_builder.py
+++ b/pyobo/document_builder.py
@@ -24,4 +24,22 @@ class OboDocumentBuilder:
         print("tag_definition")
 
     def tag_value_pair(self, tag, value):
-        self.scope.__dict__[tag.replace("-", "_")] = value
+        attribute = tag.replace("-", "_")
+        current_value = self.scope.__dict__.get(attribute)
+        if current_value is None:
+            self.scope.__dict__[attribute] = value
+            return
+        if current_value != value:
+            raise OboDocumentBuildingError.invalidTagPairMerge(tag, current_value, value)
+
+
+class OboDocumentBuildingError(Exception):
+
+    @staticmethod
+    def invalidTagPairMerge(tag, current, new):
+        result = OboDocumentBuildingError()
+        result.message = "Tag %s defined more than once with different values (%s and %s)" % (tag, current, new)
+        return result
+
+    def __init__(self):
+        pass

--- a/pyobo/document_builder.py
+++ b/pyobo/document_builder.py
@@ -47,7 +47,9 @@ class OboDocumentBuilder:
     def _extract_attribute(tag):
         attribute = tag.replace("-", "_")
         if attribute == "version":
-            attribute = "data_version"
+            return "data_version"
+        if attribute == "import":
+            return "import_"
         return attribute
 
 

--- a/pyobo/obo_document.py
+++ b/pyobo/obo_document.py
@@ -14,8 +14,15 @@ class OboDocument(Base):
         pass
 
 
-# todo version is deprecated, so not supported
-header_tvp = ['format_version', 'data_version', 'saved_by', 'auto_generated_by', 'remark', 'ontology', 'owl_axioms']
+header_tvp = ['ontology', 'format_version', 'date', 'default_namespace', 'saved_by', 'auto_generated_by',
+              'data_version', 'default_relationship_id_prefix']
+header_mtvp = ['remark', 'import_', 'subsetdef', 'synonymtypedef', 'idspace', 'treat_xrefs_as_equivalent',
+               'treat_xrefs_as_genus_differentia', 'treat_xrefs_as_reverse_genus_differentia',
+               'treat_xrefs_as_relationship',
+               'treat_xrefs_as_is_a', 'treat_xrefs_as_has_subclass', 'property_value', 'owl_axioms', 'id_mapping',
+               'relax_unique_identifier_assumption_for_namespace',
+               'relax_unique_label_assumption_for_namespace'
+               ]
 
 
 class OboHeader(Base):
@@ -23,6 +30,8 @@ class OboHeader(Base):
     def __init__(self):
         for tvp in header_tvp:
             self.__dict__[tvp] = None
+        for tvp in header_mtvp:
+            self.__dict__[tvp] = []
         pass
 
     def valid(self):

--- a/pyobo/obo_document.py
+++ b/pyobo/obo_document.py
@@ -14,7 +14,34 @@ class OboDocument(Base):
         pass
 
 
+header_tvp = ['format_version', 'data_version', 'saved_by', 'auto_generated_by', 'remark', 'ontology', 'owl_axioms']
 class OboHeader(Base):
 
     def __init__(self):
+        for tvp in header_tvp:
+            self.__dict__[tvp] = None
         pass
+# Possible header tags and status of implementation
+# format_version -> supported
+# data-version -> supported
+# date-Tag  DD:MM:YYYY sp hh:mm -> not supported
+# saved-by -> supported
+# auto-generated-by  -> supported
+# import-Tag  IRI | filepath  -> not supported
+# subsetdef-Tag  ID sp QuotedString  -> not supported
+# synonymtypedef-Tag  ID sp QuotedString  -> not supported
+#    [  SynonymScope ]  -> not supported
+# default-namespace-Tag  OBONamespace  -> not supported
+# idspace-Tag IDPrefix sp IRI  -> not supported
+#   [ sp QuotedString ]  -> not supported
+# treat-xrefs-as-equivalent-Tag IDPrefix  -> not supported
+# treat-xrefs-as-genus-differentia-Tag IDPrefix ws Rel-ID ws Class-ID  -> not supported
+# treat-xrefs-as-reverse-genus-differentia-Tag IDPrefix ws Rel-ID ws Class-ID  -> not supported
+# treat-xrefs-as-relationship-Tag IDPrefix Rel-ID  -> not supported
+# treat-xrefs-as-is_a-Tag IDPrefix  -> not supported
+# treat-xrefs-as-has-subclass-Tag IDPrefix  -> not supported
+# property_value-Tag Relation-ID ( QuotedString XSD-Type | ID ) {WhiteSpaceChar} [ QualifierBlock ] {WhiteSpaceChar} [ HiddenComment ] -> not supported
+# remark -> supported
+# ontology -> supported
+# owl-axioms -> supported
+# UnreservedToken -> supported

--- a/pyobo/obo_document.py
+++ b/pyobo/obo_document.py
@@ -36,31 +36,3 @@ class OboHeader(Base):
 
     def valid(self):
         return self.format_version is not None
-
-# Possible header tags and status of implementation
-# format_version (mandatory only one)-> supported
-# data-version (zero/one)-> supported
-# version (zero/one)-> supported
-# date-Tag  DD:MM:YYYY sp hh:mm (zero/one)-> not supported
-# saved-by (zero/one)-> supported
-# auto-generated-by (zero/one) -> supported
-# import-Tag  IRI | filepath  (Any) -> not supported
-# subsetdef-Tag  ID sp QuotedString  (any) -> not supported  (The value for this tag should contain a subset name, a space, and a quote enclosed subset description ie subsetdef: GO_SLIM "GO Slim")
-# synonymtypedef-Tag  ID sp QuotedString [  SynonymScope ] (any) -> not supported (ie synonymtypedef: UK_SPELLING "British spelling" EXACT)
-# default-namespace-Tag  OBONamespace  -> not supported
-# idspace-Tag IDPrefix sp IRI [ sp QuotedString ] (any)-> not supported (idspace: GO urn:lsid:bioontology.org:GO: "gene ontology terms")
-# treat-xrefs-as-equivalent-Tag IDPrefix  (Any)-> not supported
-# treat-xrefs-as-genus-differentia-Tag IDPrefix ws Rel-ID ws Class-ID  (Any)-> not supported
-# treat-xrefs-as-reverse-genus-differentia-Tag IDPrefix ws Rel-ID ws Class-ID  -> not supported
-# treat-xrefs-as-relationship-Tag IDPrefix Rel-ID  (Any)-> not supported
-# treat-xrefs-as-is_a-Tag IDPrefix  (Any)-> not supported
-# treat-xrefs-as-has-subclass-Tag IDPrefix  -> not supported
-# property_value-Tag Relation-ID ( QuotedString XSD-Type | ID ) {WhiteSpaceChar} [ QualifierBlock ] {WhiteSpaceChar} [ HiddenComment ] -> not supported
-# remark (any)-> supported
-# ontology -> supported (prefix of term of ontology in lowercase ie go, if extention, should be xx/yy ie go/gosubset_prok)
-# owl-axioms -> supported
-# UnreservedToken -> supported
-# default-relationship-id-prefix: OBO_REL (zero or one)
-# id-mapping (any) ie (id-mapping: part_of OBO_REL:part_of)
-# relax-unique-identifier-assumption-for-namespace (Any)
-# relax-unique-label-assumption-for-namespace (Any)

--- a/pyobo/obo_document.py
+++ b/pyobo/obo_document.py
@@ -14,34 +14,44 @@ class OboDocument(Base):
         pass
 
 
+# todo version is deprecated, so not supported
 header_tvp = ['format_version', 'data_version', 'saved_by', 'auto_generated_by', 'remark', 'ontology', 'owl_axioms']
+
+
 class OboHeader(Base):
 
     def __init__(self):
         for tvp in header_tvp:
             self.__dict__[tvp] = None
         pass
+
+    def valid(self):
+        return self.format_version is not None
+
 # Possible header tags and status of implementation
-# format_version -> supported
-# data-version -> supported
-# date-Tag  DD:MM:YYYY sp hh:mm -> not supported
-# saved-by -> supported
-# auto-generated-by  -> supported
-# import-Tag  IRI | filepath  -> not supported
-# subsetdef-Tag  ID sp QuotedString  -> not supported
-# synonymtypedef-Tag  ID sp QuotedString  -> not supported
-#    [  SynonymScope ]  -> not supported
+# format_version (mandatory only one)-> supported
+# data-version (zero/one)-> supported
+# version (zero/one)-> supported
+# date-Tag  DD:MM:YYYY sp hh:mm (zero/one)-> not supported
+# saved-by (zero/one)-> supported
+# auto-generated-by (zero/one) -> supported
+# import-Tag  IRI | filepath  (Any) -> not supported
+# subsetdef-Tag  ID sp QuotedString  (any) -> not supported  (The value for this tag should contain a subset name, a space, and a quote enclosed subset description ie subsetdef: GO_SLIM "GO Slim")
+# synonymtypedef-Tag  ID sp QuotedString [  SynonymScope ] (any) -> not supported (ie synonymtypedef: UK_SPELLING "British spelling" EXACT)
 # default-namespace-Tag  OBONamespace  -> not supported
-# idspace-Tag IDPrefix sp IRI  -> not supported
-#   [ sp QuotedString ]  -> not supported
-# treat-xrefs-as-equivalent-Tag IDPrefix  -> not supported
-# treat-xrefs-as-genus-differentia-Tag IDPrefix ws Rel-ID ws Class-ID  -> not supported
+# idspace-Tag IDPrefix sp IRI [ sp QuotedString ] (any)-> not supported (idspace: GO urn:lsid:bioontology.org:GO: "gene ontology terms")
+# treat-xrefs-as-equivalent-Tag IDPrefix  (Any)-> not supported
+# treat-xrefs-as-genus-differentia-Tag IDPrefix ws Rel-ID ws Class-ID  (Any)-> not supported
 # treat-xrefs-as-reverse-genus-differentia-Tag IDPrefix ws Rel-ID ws Class-ID  -> not supported
-# treat-xrefs-as-relationship-Tag IDPrefix Rel-ID  -> not supported
-# treat-xrefs-as-is_a-Tag IDPrefix  -> not supported
+# treat-xrefs-as-relationship-Tag IDPrefix Rel-ID  (Any)-> not supported
+# treat-xrefs-as-is_a-Tag IDPrefix  (Any)-> not supported
 # treat-xrefs-as-has-subclass-Tag IDPrefix  -> not supported
 # property_value-Tag Relation-ID ( QuotedString XSD-Type | ID ) {WhiteSpaceChar} [ QualifierBlock ] {WhiteSpaceChar} [ HiddenComment ] -> not supported
-# remark -> supported
-# ontology -> supported
+# remark (any)-> supported
+# ontology -> supported (prefix of term of ontology in lowercase ie go, if extention, should be xx/yy ie go/gosubset_prok)
 # owl-axioms -> supported
 # UnreservedToken -> supported
+# default-relationship-id-prefix: OBO_REL (zero or one)
+# id-mapping (any) ie (id-mapping: part_of OBO_REL:part_of)
+# relax-unique-identifier-assumption-for-namespace (Any)
+# relax-unique-label-assumption-for-namespace (Any)

--- a/pyobo/obo_parser.py
+++ b/pyobo/obo_parser.py
@@ -3,7 +3,7 @@ import ply.yacc as yacc
 from pyobo.obo_lexer import OboLexerBuilder
 
 
-# todo implement p_error, to siomply fail on error
+# todo implement p_error, to simply fail on error
 class OboParser:
     tokens = OboLexerBuilder.tokens
 

--- a/pyobo/tests/docbuilding_test.py
+++ b/pyobo/tests/docbuilding_test.py
@@ -1,4 +1,4 @@
-from pyobo.document_builder import OboDocumentBuilder
+from pyobo.document_builder import OboDocumentBuilder, OboDocumentBuildingError
 from pyobo.obo_document import OboDocument
 from pyobo.tests.document_assert import DocumentAsserter
 
@@ -7,6 +7,20 @@ class TestDocBuilding(DocumentAsserter):
 
     def test_should_update_header(self):
         under_test = OboDocumentBuilder()
+        under_test.tag_value_pair("hello", "world")
+        expected = OboDocument()
+        expected.header.hello = "world"
+        self.assertDocumentEquals(under_test.document, expected)
+
+    def test_should_fail_if_tag_is_present_more_than_once(self):
+        under_test = OboDocumentBuilder()
+        under_test.tag_value_pair("hello", "world")
+        with self.assertRaises(OboDocumentBuildingError):
+            under_test.tag_value_pair("hello", "anotherWorld")
+
+    def test_should_not_fail_if_tag_is_present_more_than_once_with_same_value(self):
+        under_test = OboDocumentBuilder()
+        under_test.tag_value_pair("hello", "world")
         under_test.tag_value_pair("hello", "world")
         expected = OboDocument()
         expected.header.hello = "world"

--- a/pyobo/tests/docbuilding_test.py
+++ b/pyobo/tests/docbuilding_test.py
@@ -5,25 +5,40 @@ from pyobo.tests.document_assert import DocumentAsserter
 
 class TestDocBuilding(DocumentAsserter):
 
-    def test_should_update_header(self):
+    def test_should_update_single_value_tag_header(self):
         under_test = OboDocumentBuilder()
-        under_test.tag_value_pair("hello", "world")
+        under_test.tag_value_pair("data-version", "world")
         expected = OboDocument()
-        expected.header.hello = "world"
+        expected.header.data_version = "world"
         self.assertDocumentEquals(under_test.document, expected)
 
-    def test_should_fail_if_tag_is_present_more_than_once(self):
+    def test_should_update_unknown_tag_header(self):
         under_test = OboDocumentBuilder()
-        under_test.tag_value_pair("hello", "world")
-        with self.assertRaises(OboDocumentBuildingError):
-            under_test.tag_value_pair("hello", "anotherWorld")
-
-    def test_should_not_fail_if_tag_is_present_more_than_once_with_same_value(self):
-        under_test = OboDocumentBuilder()
-        under_test.tag_value_pair("hello", "world")
         under_test.tag_value_pair("hello", "world")
         expected = OboDocument()
-        expected.header.hello = "world"
+        expected.header.hello = ["world"]
+        self.assertDocumentEquals(under_test.document, expected)
+
+    def test_should_update_multi_value_tag_header(self):
+        under_test = OboDocumentBuilder()
+        under_test.tag_value_pair("remark", "remark")
+        under_test.tag_value_pair("remark", "remark")
+        expected = OboDocument()
+        expected.header.remark = ["remark", "remark"]
+        self.assertDocumentEquals(under_test.document, expected)
+
+    def test_should_fail_if_single_value_tag_is_present_more_than_once(self):
+        under_test = OboDocumentBuilder()
+        under_test.tag_value_pair("data-version", "world")
+        with self.assertRaises(OboDocumentBuildingError):
+            under_test.tag_value_pair("data-version", "anotherWorld")
+
+    def test_should_not_fail_if_single_value_tag_is_present_more_than_once_with_same_value(self):
+        under_test = OboDocumentBuilder()
+        under_test.tag_value_pair("data-version", "world")
+        under_test.tag_value_pair("data-version", "world")
+        expected = OboDocument()
+        expected.header.data_version = "world"
         self.assertDocumentEquals(under_test.document, expected)
 
     def test_should_support_version_as_data_version(self):

--- a/pyobo/tests/docbuilding_test.py
+++ b/pyobo/tests/docbuilding_test.py
@@ -25,3 +25,10 @@ class TestDocBuilding(DocumentAsserter):
         expected = OboDocument()
         expected.header.hello = "world"
         self.assertDocumentEquals(under_test.document, expected)
+
+    def test_should_support_version_as_data_version(self):
+        under_test = OboDocumentBuilder()
+        under_test.tag_value_pair("version", "1.2")
+        expected = OboDocument()
+        expected.header.data_version = "1.2"
+        self.assertDocumentEquals(under_test.document, expected)

--- a/pyobo/tests/document_assert.py
+++ b/pyobo/tests/document_assert.py
@@ -15,4 +15,4 @@ class DocumentAsserter(unittest.TestCase):
     def assertEqualsByContent(self, actual, expected):
         actual_dict = extract_dictionary(actual)
         expected_dict = extract_dictionary(expected)
-        self.assertEqual(actual_dict, expected_dict)
+        self.assertEquals(actual_dict, expected_dict)

--- a/pyobo/tests/document_test.py
+++ b/pyobo/tests/document_test.py
@@ -9,12 +9,30 @@ def extract_dictionary(list):
 
 class TestDocument(unittest.TestCase):
 
-    def test_header_simple_tag_value_initialized_to_none(self):
+    def test_header_initialization(self):
         header = OboHeader()
+        self.assertIsNone(header.ontology)
         self.assertIsNone(header.format_version)
-        self.assertIsNone(header.data_version)
+        self.assertIsNone(header.date)
+        self.assertIsNone(header.default_namespace)
         self.assertIsNone(header.saved_by)
         self.assertIsNone(header.auto_generated_by)
-        self.assertIsNone(header.remark)
-        self.assertIsNone(header.ontology)
-        self.assertIsNone(header.owl_axioms)
+        self.assertIsNone(header.data_version)
+        self.assertIsNone(header.default_relationship_id_prefix)
+
+        self.assertEquals(header.remark, [])
+        self.assertEquals(header.import_, [])
+        self.assertEquals(header.subsetdef, [])
+        self.assertEquals(header.synonymtypedef, [])
+        self.assertEquals(header.idspace, [])
+        self.assertEquals(header.treat_xrefs_as_equivalent, [])
+        self.assertEquals(header.treat_xrefs_as_genus_differentia, [])
+        self.assertEquals(header.treat_xrefs_as_reverse_genus_differentia, [])
+        self.assertEquals(header.treat_xrefs_as_relationship, [])
+        self.assertEquals(header.treat_xrefs_as_is_a, [])
+        self.assertEquals(header.treat_xrefs_as_has_subclass, [])
+        self.assertEquals(header.property_value, [])
+        self.assertEquals(header.owl_axioms, [])
+        self.assertEquals(header.id_mapping, [])
+        self.assertEquals(header.relax_unique_identifier_assumption_for_namespace, [])
+        self.assertEquals(header.relax_unique_label_assumption_for_namespace, [])

--- a/pyobo/tests/document_test.py
+++ b/pyobo/tests/document_test.py
@@ -1,0 +1,20 @@
+import unittest
+
+from pyobo.obo_document import OboHeader
+
+
+def extract_dictionary(list):
+    return [x.__dict__ for x in list]
+
+
+class TestDocument(unittest.TestCase):
+
+    def test_header_simple_tag_value_initialized_to_none(self):
+        header = OboHeader()
+        self.assertIsNone(header.format_version)
+        self.assertIsNone(header.data_version)
+        self.assertIsNone(header.saved_by)
+        self.assertIsNone(header.auto_generated_by)
+        self.assertIsNone(header.remark)
+        self.assertIsNone(header.ontology)
+        self.assertIsNone(header.owl_axioms)

--- a/pyobo/tests/header_not_fully_supported_tags_test.py
+++ b/pyobo/tests/header_not_fully_supported_tags_test.py
@@ -1,0 +1,210 @@
+from pyobo.obo_document import OboDocument
+from pyobo.obo_reader import read
+from pyobo.tests.document_assert import DocumentAsserter
+
+
+class TestHeaderReader(DocumentAsserter):
+
+    def test_supports_invalid_date(self):
+        """This test should not pass, the date should be validated"""
+        actual = read((line for line in ["date: some invalid date"]))
+        expected = OboDocument()
+        expected.header.date = "some invalid date"
+        self.assertDocumentEquals(actual, expected)
+
+    def test_supports_date(self):
+        actual = read((line for line in ["date: 22:05:1987 10:54"]))
+        expected = OboDocument()
+        expected.header.date = "22:05:1987 10:54"
+        self.assertDocumentEquals(actual, expected)
+
+    def test_supports_single_import_but_does_not_validate_url(self):
+        actual = read((line for line in ["import: an invalid import"]))
+        expected = OboDocument()
+        expected.header.import_ = ["an invalid import"]
+        self.assertDocumentEquals(actual, expected)
+
+    def test_supports_multiple_imports_but_does_not_validate_url(self):
+        actual = read((line for line in ["import: an invalid import", "import: http://someurl/"]))
+        expected = OboDocument()
+        expected.header.import_ = ["an invalid import", "http://someurl/"]
+        self.assertDocumentEquals(actual, expected)
+
+    def test_supports_single_subsetdef_but_does_not_validate_content(self):
+        actual = read((line for line in ["subsetdef: an invalid subsetdef"]))
+        expected = OboDocument()
+        expected.header.subsetdef = ["an invalid subsetdef"]
+        self.assertDocumentEquals(actual, expected)
+
+    def test_supports_multiple_subsetdef_but_does_not_validate_content(self):
+        actual = read((line for line in ["subsetdef: an invalid subsetdef", "subsetdef: ID \"value\""]))
+        expected = OboDocument()
+        expected.header.subsetdef = ["an invalid subsetdef", 'ID "value"']
+        self.assertDocumentEquals(actual, expected)
+
+    def test_supports_single_synonymtypedef_but_does_not_validate_content(self):
+        actual = read((line for line in ["synonymtypedef: an invalid synonymtypedef"]))
+        expected = OboDocument()
+        expected.header.synonymtypedef = ["an invalid synonymtypedef"]
+        self.assertDocumentEquals(actual, expected)
+
+    def test_supports_multiple_synonymtypedef_but_does_not_validate_content(self):
+        actual = read((line for line in ["synonymtypedef: an invalid synonymtypedef", "synonymtypedef: ID \"value\""]))
+        expected = OboDocument()
+        expected.header.synonymtypedef = ["an invalid synonymtypedef", 'ID "value"']
+        self.assertDocumentEquals(actual, expected)
+
+    def test_supports_single_treat_xrefs_as_equivalent_but_does_not_validate_content(self):
+        actual = read((line for line in ["treat-xrefs-as-equivalent: an invalid treat-xrefs-as-equivalent"]))
+        expected = OboDocument()
+        expected.header.treat_xrefs_as_equivalent = ["an invalid treat-xrefs-as-equivalent"]
+        self.assertDocumentEquals(actual, expected)
+
+    def test_supports_multiple_treat_xrefs_as_equivalent_but_does_not_validate_content(self):
+        actual = read((line for line in ["treat-xrefs-as-equivalent: an invalid treat-xrefs-as-equivalent",
+                                         "treat-xrefs-as-equivalent: ID"]))
+        expected = OboDocument()
+        expected.header.treat_xrefs_as_equivalent = ["an invalid treat-xrefs-as-equivalent", 'ID']
+        self.assertDocumentEquals(actual, expected)
+
+    def test_supports_single_idspace_but_does_not_validate_content(self):
+        actual = read((line for line in ["idspace: an invalid idspace"]))
+        expected = OboDocument()
+        expected.header.idspace = ["an invalid idspace"]
+        self.assertDocumentEquals(actual, expected)
+
+    def test_supports_multiple_idspace_but_does_not_validate_content(self):
+        actual = read((line for line in ["idspace: an invalid idspace", "idspace: ID \"value\""]))
+        expected = OboDocument()
+        expected.header.idspace = ["an invalid idspace", 'ID "value"']
+        self.assertDocumentEquals(actual, expected)
+
+    def test_supports_single_relax_unique_label_assumption_for_namespace_but_does_not_validate_content(self):
+        actual = read((line for line in [
+            "relax-unique-label-assumption-for-namespace: an invalid relax-unique-label-assumption-for-namespace"]))
+        expected = OboDocument()
+        expected.header.relax_unique_label_assumption_for_namespace = [
+            "an invalid relax-unique-label-assumption-for-namespace"]
+        self.assertDocumentEquals(actual, expected)
+
+    def test_supports_multiple_relax_unique_label_assumption_for_namespace_but_does_not_validate_content(self):
+        actual = read((line for line in [
+            "relax-unique-label-assumption-for-namespace: an invalid relax-unique-label-assumption-for-namespace",
+            "relax-unique-label-assumption-for-namespace: ID \"value\""]))
+        expected = OboDocument()
+        expected.header.relax_unique_label_assumption_for_namespace = [
+            "an invalid relax-unique-label-assumption-for-namespace", 'ID "value"']
+        self.assertDocumentEquals(actual, expected)
+
+    def test_supports_single_relax_unique_identifier_assumption_for_namespace_but_does_not_validate_content(self):
+        actual = read((line for line in [
+            "relax-unique-identifier-assumption-for-namespace: an invalid relax-unique-identifier-assumption-for-namespace"]))
+        expected = OboDocument()
+        expected.header.relax_unique_identifier_assumption_for_namespace = [
+            "an invalid relax-unique-identifier-assumption-for-namespace"]
+        self.assertDocumentEquals(actual, expected)
+
+    def test_supports_multiple_relax_unique_identifier_assumption_for_namespace_but_does_not_validate_content(self):
+        actual = read((line for line in [
+            "relax-unique-identifier-assumption-for-namespace: an invalid relax-unique-identifier-assumption-for-namespace",
+            "relax-unique-identifier-assumption-for-namespace: ID \"value\""]))
+        expected = OboDocument()
+        expected.header.relax_unique_identifier_assumption_for_namespace = [
+            "an invalid relax-unique-identifier-assumption-for-namespace", 'ID "value"']
+        self.assertDocumentEquals(actual, expected)
+
+    def test_supports_single_property_value_but_does_not_validate_content(self):
+        actual = read((line for line in ["property_value: an invalid property_value"]))
+        expected = OboDocument()
+        expected.header.property_value = ["an invalid property_value"]
+        self.assertDocumentEquals(actual, expected)
+
+    def test_supports_multiple_property_value_but_does_not_validate_content(self):
+        actual = read((line for line in ["property_value: an invalid property_value", "property_value: ID \"value\""]))
+        expected = OboDocument()
+        expected.header.property_value = ["an invalid property_value", 'ID "value"']
+        self.assertDocumentEquals(actual, expected)
+
+    def test_supports_single_id_mapping_but_does_not_validate_content(self):
+        actual = read((line for line in ["id-mapping: an invalid id-mapping"]))
+        expected = OboDocument()
+        expected.header.id_mapping = ["an invalid id-mapping"]
+        self.assertDocumentEquals(actual, expected)
+
+    def test_supports_multiple_id_mapping_but_does_not_validate_content(self):
+        actual = read((line for line in ["id-mapping: an invalid id-mapping", "id-mapping: ID \"value\""]))
+        expected = OboDocument()
+        expected.header.id_mapping = ["an invalid id-mapping", 'ID "value"']
+        self.assertDocumentEquals(actual, expected)
+
+    def test_supports_single_treat_xrefs_as_has_subclass_but_does_not_validate_content(self):
+        actual = read((line for line in ["treat-xrefs-as-has-subclass: an invalid treat-xrefs-as-has-subclass"]))
+        expected = OboDocument()
+        expected.header.treat_xrefs_as_has_subclass = ["an invalid treat-xrefs-as-has-subclass"]
+        self.assertDocumentEquals(actual, expected)
+
+    def test_supports_multiple_treat_xrefs_as_has_subclass_but_does_not_validate_content(self):
+        actual = read((line for line in ["treat-xrefs-as-has-subclass: an invalid treat-xrefs-as-has-subclass",
+                                         "treat-xrefs-as-has-subclass: ID \"value\""]))
+        expected = OboDocument()
+        expected.header.treat_xrefs_as_has_subclass = ["an invalid treat-xrefs-as-has-subclass", 'ID "value"']
+        self.assertDocumentEquals(actual, expected)
+
+    def test_supports_single_treat_xrefs_as_is_a_but_does_not_validate_content(self):
+        actual = read((line for line in ["treat-xrefs-as-is_a: an invalid treat-xrefs-as-is_a"]))
+        expected = OboDocument()
+        expected.header.treat_xrefs_as_is_a = ["an invalid treat-xrefs-as-is_a"]
+        self.assertDocumentEquals(actual, expected)
+
+    def test_supports_multiple_treat_xrefs_as_is_a_but_does_not_validate_content(self):
+        actual = read((line for line in
+                       ["treat-xrefs-as-is_a: an invalid treat-xrefs-as-is_a", "treat-xrefs-as-is_a: ID \"value\""]))
+        expected = OboDocument()
+        expected.header.treat_xrefs_as_is_a = ["an invalid treat-xrefs-as-is_a", 'ID "value"']
+        self.assertDocumentEquals(actual, expected)
+
+    def test_supports_single_treat_xrefs_as_relationship_but_does_not_validate_content(self):
+        actual = read((line for line in ["treat-xrefs-as-relationship: an invalid treat-xrefs-as-relationship"]))
+        expected = OboDocument()
+        expected.header.treat_xrefs_as_relationship = ["an invalid treat-xrefs-as-relationship"]
+        self.assertDocumentEquals(actual, expected)
+
+    def test_supports_multiple_treat_xrefs_as_relationship_but_does_not_validate_content(self):
+        actual = read((line for line in ["treat-xrefs-as-relationship: an invalid treat-xrefs-as-relationship",
+                                         "treat-xrefs-as-relationship: ID \"value\""]))
+        expected = OboDocument()
+        expected.header.treat_xrefs_as_relationship = ["an invalid treat-xrefs-as-relationship", 'ID "value"']
+        self.assertDocumentEquals(actual, expected)
+
+    def test_supports_single_treat_xrefs_as_genus_differentia_but_does_not_validate_content(self):
+        actual = read(
+            (line for line in ["treat-xrefs-as-genus-differentia: an invalid treat-xrefs-as-genus-differentia"]))
+        expected = OboDocument()
+        expected.header.treat_xrefs_as_genus_differentia = ["an invalid treat-xrefs-as-genus-differentia"]
+        self.assertDocumentEquals(actual, expected)
+
+    def test_supports_multiple_treat_xrefs_as_genus_differentia_but_does_not_validate_content(self):
+        actual = read((line for line in
+                       ["treat-xrefs-as-genus-differentia: an invalid treat-xrefs-as-genus-differentia",
+                        "treat-xrefs-as-genus-differentia: ID \"value\""]))
+        expected = OboDocument()
+        expected.header.treat_xrefs_as_genus_differentia = ["an invalid treat-xrefs-as-genus-differentia", 'ID "value"']
+        self.assertDocumentEquals(actual, expected)
+
+    def test_supports_single_treat_xrefs_as_reverse_genus_differentia_but_does_not_validate_content(self):
+        actual = read(
+            (line for line in
+             ["treat-xrefs-as-reverse-genus-differentia: an invalid treat-xrefs-as-reverse-genus-differentia"]))
+        expected = OboDocument()
+        expected.header.treat_xrefs_as_reverse_genus_differentia = [
+            "an invalid treat-xrefs-as-reverse-genus-differentia"]
+        self.assertDocumentEquals(actual, expected)
+
+    def test_supports_multiple_treat_xrefs_as_reverse_genus_differentia_but_does_not_validate_content(self):
+        actual = read((line for line in
+                       ["treat-xrefs-as-reverse-genus-differentia: an invalid treat-xrefs-as-reverse-genus-differentia"
+                           , "treat-xrefs-as-reverse-genus-differentia: ID \"value\""]))
+        expected = OboDocument()
+        expected.header.treat_xrefs_as_reverse_genus_differentia = [
+            "an invalid treat-xrefs-as-reverse-genus-differentia", 'ID "value"']
+        self.assertDocumentEquals(actual, expected)

--- a/pyobo/tests/header_supported_tags_test.py
+++ b/pyobo/tests/header_supported_tags_test.py
@@ -1,0 +1,78 @@
+from pyobo.obo_document import OboDocument
+from pyobo.obo_reader import read
+from pyobo.tests.document_assert import DocumentAsserter
+
+
+class TestFullySupportedHeaderTags(DocumentAsserter):
+
+    def test_supports_format_version(self):
+        actual = read((line for line in ["format-version: 1.2"]))
+        expected = OboDocument()
+        expected.header.format_version = "1.2"
+        self.assertDocumentEquals(actual, expected)
+
+    def test_supports_ontology(self):
+        actual = read((line for line in ["ontology: hello"]))
+        expected = OboDocument()
+        expected.header.ontology = "hello"
+        self.assertDocumentEquals(actual, expected)
+
+    def test_supports_default_namespace(self):
+        actual = read((line for line in ["default-namespace: hello"]))
+        expected = OboDocument()
+        expected.header.default_namespace = "hello"
+        self.assertDocumentEquals(actual, expected)
+
+    def test_supports_data_version(self):
+        actual = read((line for line in ["data-version: 1.2"]))
+        expected = OboDocument()
+        expected.header.data_version = "1.2"
+        self.assertDocumentEquals(actual, expected)
+
+    def test_supports_version(self):
+        actual = read((line for line in ["version: 1.2"]))
+        expected = OboDocument()
+        expected.header.data_version = "1.2"
+        self.assertDocumentEquals(actual, expected)
+
+    def test_supports_saved_by(self):
+        actual = read((line for line in ["saved-by: myself"]))
+        expected = OboDocument()
+        expected.header.saved_by = "myself"
+        self.assertDocumentEquals(actual, expected)
+
+    def test_supports_auto_generated_by(self):
+        actual = read((line for line in ["auto-generated-by: myself"]))
+        expected = OboDocument()
+        expected.header.auto_generated_by = "myself"
+        self.assertDocumentEquals(actual, expected)
+
+    def test_supports_single_remark(self):
+        actual = read((line for line in ["remark: some comment"]))
+        expected = OboDocument()
+        expected.header.remark = ["some comment"]
+        self.assertDocumentEquals(actual, expected)
+
+    def test_supports_multiple_remarks(self):
+        actual = read((line for line in ["remark: some comment", "remark: some other comment"]))
+        expected = OboDocument()
+        expected.header.remark = ["some comment", "some other comment"]
+        self.assertDocumentEquals(actual, expected)
+
+    def test_supports_single_owl_axiom(self):
+        actual = read((line for line in ["owl-axioms: an axiom"]))
+        expected = OboDocument()
+        expected.header.owl_axioms = ["an axiom"]
+        self.assertDocumentEquals(actual, expected)
+
+    def test_supports_multiple_owl_axioms(self):
+        actual = read((line for line in ["owl-axioms: an axiom", "owl-axioms: another axiom"]))
+        expected = OboDocument()
+        expected.header.owl_axioms = ["an axiom", "another axiom"]
+        self.assertDocumentEquals(actual, expected)
+
+    def test_supports_default_relationship_id_prefix(self):
+        actual = read((line for line in ["default-relationship-id-prefix: prefix"]))
+        expected = OboDocument()
+        expected.header.default_relationship_id_prefix = "prefix"
+        self.assertDocumentEquals(actual, expected)

--- a/pyobo/tests/lexer_test.py
+++ b/pyobo/tests/lexer_test.py
@@ -53,4 +53,4 @@ class TestLexer(unittest.TestCase):
     def assertEqualsByContent(self, actual, expected):
         actual_dict = extract_dictionary(actual)
         expected_dict = extract_dictionary(expected)
-        self.assertEqual(actual_dict, expected_dict)
+        self.assertEquals(actual_dict, expected_dict)

--- a/pyobo/tests/lexer_test.py
+++ b/pyobo/tests/lexer_test.py
@@ -29,6 +29,7 @@ class TestLexer(unittest.TestCase):
 
     def test_should_recognise_obo_strings(self):
         lexer = OboLexerBuilder().new_lexer();
+        lexer.begin("value")
         actual = OboLexerBuilder().tokenize(lexer, """It can contain any characters but new lines \u0145 \\a""")
         expected = [to_token(lexer, "OBO_UNQUOTED_STRING",
                              "It can contain any characters but new lines \u0145 \\a", 1, 0)]
@@ -44,10 +45,10 @@ class TestLexer(unittest.TestCase):
     def test_should_ignore_spaces_and_tab(self):
         lexer = OboLexerBuilder().new_lexer();
         actual = OboLexerBuilder().tokenize(lexer, """  a_valid_tag-AZ_8: \t"""
-                                            + """It can contain any characters but new lines \u0145 \\a""")
+                                            + """It can contain any characters \t but new lines \u0145 \\a""")
         expected = [
             to_token(lexer, "TAG", "a_valid_tag-AZ_8", 1, 2),
-            to_token(lexer, "OBO_UNQUOTED_STRING", "It can contain any characters but new lines \u0145 \\a", 1, 21)]
+            to_token(lexer, "OBO_UNQUOTED_STRING", "It can contain any characters \t but new lines \u0145 \\a", 1, 21)]
         self.assertEqualsByContent(actual, expected)
 
     def assertEqualsByContent(self, actual, expected):

--- a/pyobo/tests/reader_test.py
+++ b/pyobo/tests/reader_test.py
@@ -9,5 +9,5 @@ class TestReader(DocumentAsserter):
         actual = read((line for line in ["format-version: 1.2", "another-format-version: 1.3"]))
         expected = OboDocument()
         expected.header.format_version = "1.2"
-        expected.header.another_format_version = "1.3"
+        expected.header.another_format_version = ["1.3"]
         self.assertDocumentEquals(actual, expected)


### PR DESCRIPTION
Support parsing of most header tags, multi value tags are supported as lists
Special handling for version, which is deprecated and replaced by data-version
Special handling for import, which is a python keyword
Support for semicolons in obo string
Added unit tests for recognized header tags